### PR TITLE
Add macOS x86 tests and enable codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: Install bundler and dependencies
           command: |
             apt update -y
-            apt install -y ruby
+            apt install -y ruby ruby-dev
             gem install bundler
             bundle install
 
@@ -102,9 +102,8 @@ jobs:
           command: |
             yum -y install epel-release yum-utils
             yum -y config-manager --set-enabled powertools
-            yum -y install wget redhat-lsb-core sudo openblas R texinfo-tex openblas-devel ruby
+            yum -y install wget redhat-lsb-core sudo openblas R texinfo-tex openblas-devel ruby ruby-devel
             gem install bundler
-            bundle update --bundler
             bundle install
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,6 @@ jobs:
           path: /tmp/test-results/out
           destination: artifact-file
 
-      - run:
-          name: Upload reports to Codecov
-          command: |
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            chmod +x codecov
-            ./codecov -f coverage/codecov-result.json -Z
-
   ubuntu-20-04:
     environment:
       TZ: Europe/Zurich
@@ -70,8 +63,7 @@ jobs:
           command: |
             apt update -y
             apt install -y ruby ruby-dev
-            gem install bundler
-            bundle install
+            gem install bashcov
 
       - run:
           name: "Install apt deps"
@@ -102,9 +94,8 @@ jobs:
           command: |
             yum -y install epel-release yum-utils
             yum -y config-manager --set-enabled powertools
-            yum -y install wget redhat-lsb-core sudo openblas R texinfo-tex openblas-devel ruby ruby-devel
-            gem install bundler
-            bundle install
+            yum -y install wget redhat-lsb-core sudo openblas R texinfo-tex openblas-devel ruby
+            gem install bashcov
 
       - run:
           name: Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2.1
+orbs:
+  codecov: codecov/codecov@3.2.2
 jobs:
   ubuntu-21-10:
     environment:
@@ -61,10 +63,7 @@ jobs:
 
       - run:
           name: Install bundler and dependencies
-          command: apt update -y && apt install -y ruby && bundle update --bundler && bundle install
-      - run:
-          name: Run scripts
-          command: bashcov script.sh
+          command: apt update -y && apt install -y ruby && gem install bundler && bundle update --bundler && bundle install
 
       - run:
           name: "Install apt deps"
@@ -75,34 +74,12 @@ jobs:
               r-base-core libcurl4-openssl-dev file tzdata
 
       - run:
-          name: "Install rcli"
-          command: |
-            shc -f rcli.sh && \
-            mv rcli.sh.x /usr/local/bin/rcli
-
-      - run:
-          name: "Install R"
-          command: |
-            mkdir -p /tmp/test-results
-            chmod +x /usr/local/bin/rcli
-            rcli install 4.1.2 >> /tmp/test-results/out
-            R -q -s -e "R.version.string" > /tmp/test-results/out
-            rcli install 3.6.3 >> /tmp/test-results/out
-            R -q -s -e "R.version.string" >> /tmp/test-results/out
-            rcli switch 4.1.2 >> /tmp/test-results/out
-            R -q -s -e "R.version.string" >> /tmp/test-results/out
-            if [[ $(diff tests/ubuntu-20.04/test-out.txt /tmp/test-results/out)  == "" ]] ; then exit 0; else exit 1 ; fi
+          name: Tests
+          command: bashcov tests/ubuntu-20.04/test-ubuntu-20.04.sh
 
       - store_artifacts:
           path: /tmp/test-results/out
           destination: artifact-file
-
-      - run:
-          name: Upload reports to Codecov
-          command: |
-            curl -Os https://uploader.codecov.io/latest/linux/codecov
-            chmod +x codecov
-            ./codecov -f coverage/codecov-result.json -Z
 
   centos8:
     environment:
@@ -215,8 +192,10 @@ jobs:
 workflows:
   test:
     jobs:
-      - ubuntu-20-04
-      - centos8
+      - ubuntu-20-04:
+          post-steps:
+            - codecov/upload:
+              file: coverage/codecov-result.json
 
   # CRON job daily at 4 am in the morning
   # - runs the "build" job on the master branch and builds package cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
           command: |
             yum -y install epel-release yum-utils
             yum -y config-manager --set-enabled powertools
-            yum -y install wget redhat-lsb-core sudo openblas R texinfo-tex openblas-devel ruby
+            yum -y install wget redhat-lsb-core sudo openblas R texinfo-tex openblas-devel ruby ruby-devel
             gem install bashcov
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ jobs:
 
       - run:
           name: Install bundler and dependencies
-          command: apt update -y && apt install -y ruby && bundle update --bundler && bundle install
+          command: |
+            apt update -y
+            apt install -y ruby
+            bundle install
       - run:
           name: Run scripts
           command: bashcov script.sh
@@ -182,6 +185,10 @@ workflows:
   test:
     jobs:
       - ubuntu-20-04:
+          post-steps:
+            - codecov/upload:
+              file: coverage/codecov-result.json
+      - centos8:
           post-steps:
             - codecov/upload:
               file: coverage/codecov-result.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,10 @@ jobs:
 
       - run:
           name: Install bundler and dependencies
-          command: apt update -y && apt install -y ruby && gem install bundler && bundle update --bundler && bundle install
+            apt update -y
+            apt install -y ruby
+            gem install bundler
+            bundle install
 
       - run:
           name: "Install apt deps"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   codecov: codecov/codecov@3.2.2
+
 jobs:
   ubuntu-21-10:
     environment:
@@ -94,26 +95,14 @@ jobs:
           command: |
             yum -y install epel-release yum-utils
             yum -y config-manager --set-enabled powertools
-            yum -y install wget redhat-lsb-core sudo openblas shc R texinfo-tex openblas-devel
+            yum -y install wget redhat-lsb-core sudo openblas R texinfo-tex openblas-devel ruby
+            gem install bundler
+            bundle update --bundler
+            bundle install
 
       - run:
-          name: "Install rcli"
-          command: |
-            mkdir -p /tmp/test-results
-            shc -f rcli.sh && \
-            mv rcli.sh.x /usr/local/bin/rcli
-            chmod +x /usr/local/bin/rcli
-
-      - run:
-          name: "Install R"
-          command: |
-            rcli install 4.1.2 >> /tmp/test-results/out
-            R -q -s -e "R.version.string" > /tmp/test-results/out
-            rcli install 3.6.3 >> /tmp/test-results/out
-            R -q -s -e "R.version.string" >> /tmp/test-results/out
-            rcli switch 4.1.2 >> /tmp/test-results/out
-            R -q -s -e "R.version.string" >> /tmp/test-results/out
-            if [[ $(diff tests/centos8/test-out.txt /tmp/test-results/out)  == "" ]] ; then exit 0; else diff --unified tests/centos8/test-out.txt /tmp/test-results/out && exit 1 ; fi
+          name: Tests
+          command: bashcov tests/centos8/test-centos8.sh
 
       - store_artifacts:
           path: /tmp/test-results/out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,13 @@ jobs:
       - checkout
 
       - run:
+          name: Install bundler and dependencies
+          command: apt update -y && apt install -y ruby && bundle update --bundler && bundle install
+      - run:
+          name: Run scripts
+          command: bashcov script.sh
+
+      - run:
           name: "Install apt deps"
           command: |
             apt update -y
@@ -36,6 +43,13 @@ jobs:
           path: /tmp/test-results/out
           destination: artifact-file
 
+      - run:
+          name: Upload reports to Codecov
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov -f coverage/codecov-result.json -Z
+
   ubuntu-20-04:
     environment:
       TZ: Europe/Zurich
@@ -44,6 +58,13 @@ jobs:
       - image: ubuntu:20.04
     steps:
       - checkout
+
+      - run:
+          name: Install bundler and dependencies
+          command: apt update -y && apt install -y ruby && bundle update --bundler && bundle install
+      - run:
+          name: Run scripts
+          command: bashcov script.sh
 
       - run:
           name: "Install apt deps"
@@ -75,6 +96,13 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results/out
           destination: artifact-file
+
+      - run:
+          name: Upload reports to Codecov
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov -f coverage/codecov-result.json -Z
 
   centos8:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ jobs:
 
       - run:
           name: Install bundler and dependencies
+          command: |
             apt update -y
             apt install -y ruby
             gem install bundler

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org')" > /dev/null
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
-          R -q -s -e "library('brew')"
+          R -q -s -e "library('gam')"
 
       - name: "Upload artifacts"
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,9 @@ jobs:
 
       - name: Install R
         shell: bash
-        run: brew install --cask r
+        run: |
+          brew install --cask r
+          echo -e "Architecture: $(arch)"
 
       - name: Tests
         shell: bash
@@ -20,10 +22,11 @@ jobs:
           echo -e "SYSLIB: $(R -q -s -e "tail(.libPaths())" | cut -c 6- | sed 's/.$//')"
           mkdir -p /tmp/test-results && touch /tmp/test-results/out
           ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out
-          ./rcli.sh install 4.1.0 && R -q -s -e "R.version.string" >> /tmp/test-results/out
+          ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out
+          echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 >> /tmp/test-results/out
           R -q -s -e "install.packages('brew')"
-          ./rcli.sh switch 4.1.0  >> /tmp/test-results/out
+          ./rcli.sh switch 4.0.5 >> /tmp/test-results/out
           R -q -s -e "install.packages('magrittr')"
           ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
           R -q -s -e "library('brew')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,12 @@ jobs:
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out.txt
           R -q -s -e "library('gam')" >> /tmp/test-results/out.txt
+          echo -e "#### Installing R devel"
+          ./rcli.sh install devel
+          echo -e "#### Switching devel -> 4.0.5"
+          ./rcli.sh switch 4.0.5 >> /tmp/test-results/out.txt
+          R -q -s -e "library('cli')" >> /tmp/test-results/out.txt
+          # if [[ $(diff tests/macos/test-out-x86.txt /tmp/test-results/out.txt)  == "" ]] ; then exit 0; else exit 1 ; fi
 
       - name: "Upload artifacts"
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+  pull_request:
+
+name: rcli-macOS
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install R
+        run: |
+          brew install --cask r
+        shell: bash
+
+      - name: Tests
+        run: |
+          mkdir -p /tmp/test-results && touch /tmp/test-results/out
+          ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out
+          ./rcli.sh install 4.1.0 && R -q -s -e "R.version.string" >> /tmp/test-results/out
+          ./rcli.sh switch 4.1.2 >> /tmp/test-results/out
+          R -q -s -e "install.packages('brew')"
+          ./rcli.sh switch 4.1.0  >> /tmp/test-results/out
+          R -q -s -e "install.packages('magrittr')"
+          ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
+          R -q -s -e "library('brew')"
+        shell: bash
+
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,17 +26,17 @@ jobs:
       - name: Tests
         shell: bash
         run: |
-          mkdir -p /tmp/test-results && touch /tmp/test-results/out
-          ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out
-          ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out
+          mkdir -p /tmp/test-results && touch /tmp/test-results/out.txt
+          ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out.txt
+          ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out.txt
           echo -e "#### Switching 4.0.5 -> 4.1.2"
-          ./rcli.sh switch 4.1.2 >> /tmp/test-results/out
+          ./rcli.sh switch 4.1.2 >> /tmp/test-results/out.txt
           R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.1.2 -> 4.0.5"
-          ./rcli.sh switch 4.0.5 --debug >> /tmp/test-results/out
+          ./rcli.sh switch 4.0.5 --debug >> /tmp/test-results/out.txt
           R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.0.5 -> 4.1.2"
-          ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out
+          ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out.txt
           ls /opt/R/4.1.2/syslib-bak
           ls /Library/Frameworks/R.framework/Versions/4.1/Resources/library
           R -q -s -e "installed.packages()[, 'Package']"
@@ -46,7 +46,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v2
         with:
-          path: /tmp/test-results/out
+          path: /tmp/test-results/out.txt
 
       - name: Upload reports to Codecov
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-ruby@v1
+      - name: Install Ruby dependencies
+        run: bundle update --bundler && bundle install
+      - name: Run script
+        run: bashcov rcli.sh
+
       - name: Install R
         shell: bash
         run: |
@@ -36,3 +42,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: /tmp/test-results/out
+
+      - name: Upload reports to Codecov
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov -f coverage/codecov-result.json -Z

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           ruby-version: 2.7
       - name: Install Ruby dependencies
-        run: bundle update --bundler && bundle install
+        run: bundle install
       - name: Run script
         run: bashcov rcli.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install R
+        shell: bash
+        run: brew install --cask r
+
       - name: Tests
+        shell: bash
         run: |
           brew install --cask r
           echo -e "SYSLIB: $(R -q -s -e "tail(.libPaths())" | cut -c 6- | sed 's/.$//')"
@@ -23,7 +28,6 @@ jobs:
           R -q -s -e "install.packages('magrittr')"
           ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
           R -q -s -e "library('brew')"
-        shell: bash
 
       - name: "Upload artifacts"
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,10 @@ jobs:
           ls /opt/R/4.0.5
           R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.1.2 -> 4.0.5"
-          ./rcli.sh switch 4.0.5 >> /tmp/test-results/out
+          ./rcli.sh switch 4.0.5 --debug >> /tmp/test-results/out
           R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.0.5 -> 4.1.2"
-          ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
+          ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out
           R -q -s -e "library('gam')"
 
       - name: "Upload artifacts"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,20 +22,18 @@ jobs:
         shell: bash
         run: |
           brew install --cask r
-          echo -e "Architecture: $(arch)"
 
       - name: Tests
         shell: bash
         run: |
-          echo -e "SYSLIB: $(R -q -s -e "tail(.libPaths())" | cut -c 6- | sed 's/.$//')"
           mkdir -p /tmp/test-results && touch /tmp/test-results/out
           ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out
           ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 >> /tmp/test-results/out
-          R -q -s -e "install.packages('brew')"
+          R -q -s -e "install.packages('brew', repos = 'https://cran.us.r-project.org')"
           ./rcli.sh switch 4.0.5 >> /tmp/test-results/out
-          R -q -s -e "install.packages('magrittr')"
+          R -q -s -e "install.packages('magrittr', repos = 'https://cran.us.r-project.org')"
           ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
           R -q -s -e "library('brew')"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,13 @@ jobs:
           ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 >> /tmp/test-results/out
-          R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org')" > /dev/null
+          echo -e "Listing R dirs"
+          ls /opt/R/4.1.2
+          ls /opt/R/4.0.5
+          R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.1.2 -> 4.0.5"
           ./rcli.sh switch 4.0.5 >> /tmp/test-results/out
-          R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org')" > /dev/null
+          R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
           R -q -s -e "library('gam')"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,6 @@ jobs:
           ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 >> /tmp/test-results/out
-          echo -e "Listing R dirs"
-          ls /opt/R/4.1.2
-          ls /opt/R/4.0.5
           R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.1.2 -> 4.0.5"
           ./rcli.sh switch 4.0.5 --debug >> /tmp/test-results/out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
 name: rcli-macOS
 
 jobs:
-  test:
+  test-rcli:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,6 +13,7 @@ jobs:
       - name: Install R
         run: |
           brew install --cask r
+          echo -e "SYSLIB: $(R -q -s -e "tail(.libPaths())" | cut -c 6- | sed 's/.$//')"
         shell: bash
 
       - name: Tests
@@ -28,4 +29,8 @@ jobs:
           R -q -s -e "library('brew')"
         shell: bash
 
-
+      - name: "Upload artifacts"
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          path: /tmp/test-results/out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
       - name: Install Ruby dependencies
         run: bundle update --bundler && bundle install
       - name: Run script

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out.txt
-          R -q -s -e "library('gam')"
+          R -q -s -e "library('gam')" >> /tmp/test-results/out.txt
 
       - name: "Upload artifacts"
         if: always()
@@ -45,9 +45,11 @@ jobs:
         with:
           path: /tmp/test-results/out.txt
 
-      - name: Upload reports to Codecov
-        shell: bash
-        run: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-          ./codecov -f coverage/codecov-result.json -Z
+      - uses: codecov/codecov-action@v2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          files: coverage/codecov-result.json
+          flags: unittests # optional
+          name: rcli
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
           ruby-version: 2.7
       - name: Install Ruby dependencies
         run: bundle install
-      - name: Bashcov
-        run: bashcov rcli.sh
 
       - name: Install R
         shell: bash
@@ -25,25 +23,7 @@ jobs:
 
       - name: Tests
         shell: bash
-        run: |
-          mkdir -p /tmp/test-results && touch /tmp/test-results/out.txt
-          ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out.txt
-          ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out.txt
-          echo -e "#### Switching 4.0.5 -> 4.1.2"
-          ./rcli.sh switch 4.1.2 >> /tmp/test-results/out.txt
-          R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
-          echo -e "#### Switching 4.1.2 -> 4.0.5"
-          ./rcli.sh switch 4.0.5 --debug >> /tmp/test-results/out.txt
-          R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
-          echo -e "#### Switching 4.0.5 -> 4.1.2"
-          ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out.txt
-          R -q -s -e "library('gam')" >> /tmp/test-results/out.txt
-          echo -e "#### Installing R devel"
-          ./rcli.sh install devel
-          echo -e "#### Switching devel -> 4.0.5"
-          ./rcli.sh switch 4.0.5 >> /tmp/test-results/out.txt
-          R -q -s -e "library('cli')" >> /tmp/test-results/out.txt
-          # if [[ $(diff tests/macos/test-out-x86.txt /tmp/test-results/out.txt)  == "" ]] ; then exit 0; else exit 1 ; fi
+        run: bashcov tests/macos/test.sh
 
       - name: "Upload artifacts"
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           ruby-version: 2.7
       - name: Install Ruby dependencies
         run: bundle install
-      - name: Run script
+      - name: Bashcov
         run: bashcov rcli.sh
 
       - name: Install R
@@ -37,9 +37,6 @@ jobs:
           R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out.txt
-          ls /opt/R/4.1.2/syslib-bak
-          ls /Library/Frameworks/R.framework/Versions/4.1/Resources/library
-          R -q -s -e "installed.packages()[, 'Package']"
           R -q -s -e "library('gam')"
 
       - name: "Upload artifacts"
@@ -49,6 +46,7 @@ jobs:
           path: /tmp/test-results/out.txt
 
       - name: Upload reports to Codecov
+        shell: bash
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov
           chmod +x codecov

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
           R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" > /dev/null
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 --debug  >> /tmp/test-results/out
+          ls /opt/R/4.1.2/syslib-bak
+          ls /Library/Frameworks/R.framework/Versions/4.1/Resources/library
+          R -q -s -e "installed.packages()[, 'Package']"
           R -q -s -e "library('gam')"
 
       - name: "Upload artifacts"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,9 +31,11 @@ jobs:
           ./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >> /tmp/test-results/out
           echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2 >> /tmp/test-results/out
-          R -q -s -e "install.packages('brew', repos = 'https://cran.us.r-project.org')"
+          R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org')" > /dev/null
+          echo -e "#### Switching 4.1.2 -> 4.0.5"
           ./rcli.sh switch 4.0.5 >> /tmp/test-results/out
-          R -q -s -e "install.packages('magrittr', repos = 'https://cran.us.r-project.org')"
+          R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org')" > /dev/null
+          echo -e "#### Switching 4.0.5 -> 4.1.2"
           ./rcli.sh switch 4.1.2  >> /tmp/test-results/out
           R -q -s -e "library('brew')"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,41 +1,41 @@
-on:
-  push:
-  pull_request:
+# on:
+#   push:
+#   pull_request:
 
-name: rcli-macOS
+# name: rcli-macOS
 
-jobs:
-  test-rcli:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
+# jobs:
+#   test-rcli:
+#     runs-on: macos-latest
+#     steps:
+#       - uses: actions/checkout@v2
 
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: 2.7
-      - name: Install Ruby dependencies
-        run: bundle install
+#       - uses: ruby/setup-ruby@v1
+#         with:
+#           ruby-version: 2.7
+#       - name: Install Ruby dependencies
+#         run: bundle install
 
-      - name: Install R
-        shell: bash
-        run: |
-          brew install --cask r
+#       - name: Install R
+#         shell: bash
+#         run: |
+#           brew install --cask r
 
-      - name: Tests
-        shell: bash
-        run: bashcov tests/macos/test.sh
+#       - name: Tests
+#         shell: bash
+#         run: bashcov tests/macos/test.sh
 
-      - name: "Upload artifacts"
-        if: always()
-        uses: actions/upload-artifact@v2
-        with:
-          path: /tmp/test-results/out.txt
+#       - name: "Upload artifacts"
+#         if: always()
+#         uses: actions/upload-artifact@v2
+#         with:
+#           path: /tmp/test-results/out.txt
 
-      - uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          files: coverage/codecov-result.json
-          flags: unittests # optional
-          name: rcli
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)
+#       - uses: codecov/codecov-action@v2
+#         with:
+#           token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+#           files: coverage/codecov-result.json
+#           flags: unittests # optional
+#           name: rcli
+#           fail_ci_if_error: true # optional (default = false)
+#           verbose: true # optional (default = false)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Tests
         shell: bash
         run: |
-          brew install --cask r
           echo -e "SYSLIB: $(R -q -s -e "tail(.libPaths())" | cut -c 6- | sed 's/.$//')"
           mkdir -p /tmp/test-results && touch /tmp/test-results/out
           ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,14 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install R
+      - name: Tests
         run: |
           brew install --cask r
           echo -e "SYSLIB: $(R -q -s -e "tail(.libPaths())" | cut -c 6- | sed 's/.$//')"
-        shell: bash
-
-      - name: Tests
-        run: |
           mkdir -p /tmp/test-results && touch /tmp/test-results/out
           ./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >> /tmp/test-results/out
           ./rcli.sh install 4.1.0 && R -q -s -e "R.version.string" >> /tmp/test-results/out

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,4 @@
+require 'codecov'
+require 'simplecov'
+
+SimpleCov.formatter = Codecov::SimpleCov::Formatter

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'bashcov'
+gem 'codecov'

--- a/rcli.sh
+++ b/rcli.sh
@@ -194,6 +194,10 @@ function switch() {
         TARGET_R_CUT_ARCH=$R_CUT
       fi
 
+      if [[ $ARG_DEBUG == 1 ]]; then
+        echo -e "DEBUG: switch(): Backing up system library to /opt/R/$CURRENT_R_VERSION_ARCH/syslib-bak"
+      fi
+
       sudo mkdir -p /opt/R/$currentR/syslib-bak
       sudo cp -fR $SYSLIB/* /opt/R/$CURRENT_R_VERSION_ARCH/syslib-bak
 
@@ -206,6 +210,9 @@ function switch() {
 
       # only restore if R_VERSION has a syslib-bak
       if [[ $(test -d /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
+        if [[ $ARG_DEBUG == 1 ]]; then
+          echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
+        fi
         sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/ /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
@@ -236,6 +243,9 @@ function switch() {
       ### restore syslib from target version if it exists
       # only restore if R_VERSION has a syslib-bak
       if [[ $(test -d /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
+        if [[ $ARG_DEBUG == 1 ]]; then
+          echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
+        fi
         sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
@@ -283,7 +293,7 @@ function switch() {
     if [[ $(find $SYSLIB -maxdepth 1 -type d | wc -l | xargs) > 31 ]]; then
 
       if [[ $ARG_DEBUG == 1 ]]; then
-        echo -e "DEBUG: switch(): Backing up system libraries"
+        echo -e "DEBUG: switch(): Backing up system library to /opt/R/$CURRENT_R_VERSION_ARCH/syslib-bak"
       fi
 
       sudo mkdir -p /opt/R/$CURRENT_R_VERSION_ARCH/syslib-bak
@@ -312,7 +322,7 @@ function switch() {
       # only restore if R_VERSION has a syslib-bak
       if [[ $(test -d /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
         if [[ $ARG_DEBUG == 1 ]]; then
-          echo -e "DEBUG: switch(): Restoring existing syslib"
+          echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
         fi
         sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
@@ -343,6 +353,9 @@ function switch() {
 
       # only restore if R_VERSION has a syslib-bak
       if [[ $(test -d /opt/R/$R_VERSION/syslib-bak && echo "true" || echo "false") == "true" ]]; then
+        if [[ $ARG_DEBUG == 1 ]]; then
+          echo -e "DEBUG: switch(): Restoring existing syslib"
+        fi
         sudo cp -fR /opt/R/$R_VERSION/syslib-bak/ /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 

--- a/rcli.sh
+++ b/rcli.sh
@@ -280,7 +280,10 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT/Resources /Library/Frameworks/R.framework 2>/dev/null
 
-      if [[ $ARG_ARCH == "x86_64" || $(arch) != "arm64" ]]; then
+      if [[ $ARG_ARCH == "x86_64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION
+        TARGET_R_CUT_ARCH=$R_CUT
+      elif [[ $(arch) != "arm64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
       else

--- a/rcli.sh
+++ b/rcli.sh
@@ -506,6 +506,7 @@ function install() {
 
     currentR=$(echo $(R --version) | cut -c 11-15)
     currentArch=$(R -s -q -e "Sys.info()[['machine']]" | cut -c 6- | sed 's/.$//')
+    SYSLIB=$(R -q -s -e "tail(.libPaths())" | cut -c 6- | sed 's/.$//')
 
     # backup current system library if non exists yet
     # this ensure that new rcli users don't loose their packages if they only use a system library

--- a/rcli.sh
+++ b/rcli.sh
@@ -205,8 +205,8 @@ function switch() {
       sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/TARGET_R_CUT_ARCH/Resources /Library/Frameworks/R.framework/ 2>/dev/null
 
-      # need 775 permissions
-      sudo chmod 775 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+      # need 777 permissions
+      sudo chmod 777 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
 
       # only restore if R_VERSION has a syslib-bak
       if [[ $(test -d /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
@@ -214,6 +214,8 @@ function switch() {
           echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
         fi
         sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        # permissions again after copying
+        sudo chmod 777 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       # clean
@@ -237,8 +239,8 @@ function switch() {
         TARGET_R_CUT_ARCH=$R_CUT
       fi
 
-      # need 775 permissions
-      sudo chmod 775 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+      # need 777 permissions
+      sudo chmod 777 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
 
       ### restore syslib from target version if it exists
       # only restore if R_VERSION has a syslib-bak
@@ -247,6 +249,8 @@ function switch() {
           echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
         fi
         sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/* /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        # permissions again after copying
+        sudo chmod 777 /Library/Frameworks/R.framework/Resources
       fi
 
       sudo rm -rf /Library/Frameworks/R.framework/Versions/syslib-bak
@@ -315,8 +319,8 @@ function switch() {
         TARGET_R_CUT_ARCH=$R_CUT
       fi
 
-      # need 775 permissions
-      sudo chmod 775 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+      # need 777 permissions
+      sudo chmod 777 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
 
       ### restore syslib from target version if it exists
       # only restore if R_VERSION has a syslib-bak
@@ -325,6 +329,8 @@ function switch() {
           echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
         fi
         sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/* /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        # permissions again after copying
+        sudo chmod 777 /Library/Frameworks/R.framework/Resources
       fi
 
       # clean
@@ -348,8 +354,8 @@ function switch() {
         TARGET_R_CUT_ARCH=$R_CUT
       fi
 
-      # need 775 permissions
-      sudo chmod 775 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+      # need 777 permissions
+      sudo chmod 777 /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
 
       # only restore if R_VERSION has a syslib-bak
       if [[ $(test -d /opt/R/$R_VERSION/syslib-bak && echo "true" || echo "false") == "true" ]]; then
@@ -357,6 +363,8 @@ function switch() {
           echo -e "DEBUG: switch(): Restoring existing syslib"
         fi
         sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/* /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        # permissions again after copying
+        sudo chmod 777 /Library/Frameworks/R.framework/Resources
       fi
 
       sudo rm -rf /Library/Frameworks/R.framework/Versions/syslib-bak
@@ -509,6 +517,7 @@ function install() {
     sudo rm -rf /Library/Frameworks/R.framework/Versions
     sudo installer -pkg /tmp/R-${R_VERSION}-arm64.pkg -target / >/dev/null
     rm /tmp/R-${R_VERSION}-arm64.pkg
+
     if [[ $R_VERSION == "devel" ]]; then
       R_VERSION=$(echo $(R -s -q -e 'paste(R.version[["major"]], R.version[["minor"]], sep = ".")') | cut -c 6-10)
       R_CUT=$(echo $R_VERSION | cut -c 1-3)
@@ -519,6 +528,7 @@ function install() {
 
     if [[ $RESTORE_SYSLIB == "true" ]]; then
       sudo cp -fR /opt/R/$R_VERSION-arm64/syslib-bak/* $SYSLIB
+      sudo chmod 777 /Library/Frameworks/R.framework/Resources
     fi
 
   else

--- a/rcli.sh
+++ b/rcli.sh
@@ -180,13 +180,18 @@ function switch() {
         CURRENT_R_VERSION_ARCH=$currentR
       fi
 
-      # backup existing user library
+      if [[ $(arch) == "x86_64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION
+        TARGET_R_CUT_ARCH=$R_CUT
+      fi
+      if [[ $(arch) == "arm64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
+        TARGET_R_CUT_ARCH=$R_CUT-arm64
+      fi
+      # override with user preference
       if [[ $ARG_ARCH == "x86_64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
-      else
-        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
-        TARGET_R_CUT_ARCH=$R_CUT-arm64
       fi
 
       sudo mkdir -p /opt/R/$currentR/syslib-bak
@@ -213,12 +218,18 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION-arm64/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT-arm64/Resources /Library/Frameworks/R.framework/ 2>/dev/null
 
+      if [[ $(arch) == "x86_64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION
+        TARGET_R_CUT_ARCH=$R_CUT
+      fi
+      if [[ $(arch) == "arm64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
+        TARGET_R_CUT_ARCH=$R_CUT-arm64
+      fi
+      # override with user preference
       if [[ $ARG_ARCH == "x86_64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
-      else
-        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
-        TARGET_R_CUT_ARCH=$R_CUT-arm64
       fi
 
       # need 775 permissions
@@ -226,8 +237,8 @@ function switch() {
 
       ### restore syslib from target version if it exists
       # only restore if R_VERSION has a syslib-bak
-      if [[ $(test -d /opt/R/TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
-        sudo cp -fR /opt/R/TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+      if [[ $(test -d /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
+        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       sudo rm -rf /Library/Frameworks/R.framework/Versions/syslib-bak
@@ -284,15 +295,18 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT/Resources /Library/Frameworks/R.framework 2>/dev/null
 
+      if [[ $(arch) == "x86_64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION
+        TARGET_R_CUT_ARCH=$R_CUT
+      fi
+      if [[ $(arch) == "arm64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
+        TARGET_R_CUT_ARCH=$R_CUT-arm64
+      fi
+      # override with user preference
       if [[ $ARG_ARCH == "x86_64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
-      elif [[ $(arch) != "arm64" ]]; then
-        TARGET_R_VERSION_ARCH=$R_VERSION
-        TARGET_R_CUT_ARCH=$R_CUT
-      else
-        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
-        TARGET_R_CUT_ARCH=$R_CUT-arm64
       fi
 
       # need 775 permissions
@@ -300,11 +314,11 @@ function switch() {
 
       ### restore syslib from target version if it exists
       # only restore if R_VERSION has a syslib-bak
-      if [[ $(test -d /opt/R/TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
+      if [[ $(test -d /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
         if [[ $ARG_DEBUG == 1 ]]; then
           echo -e "DEBUG: switch(): Restoring existing syslib"
         fi
-        sudo cp -fR /opt/R/TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       # clean

--- a/rcli.sh
+++ b/rcli.sh
@@ -532,7 +532,7 @@ function install() {
     sudo cp -fR /Library/Frameworks/R.framework/Versions/Current /opt/R/$R_VERSION/ 2>/dev/null
 
     if [[ $RESTORE_SYSLIB == "true" ]]; then
-      sudo cp -fR /opt/R/$R_VERSION-arm64/syslib-bak/* $SYSLIB
+      sudo cp -fR /opt/R/$R_VERSION/syslib-bak/* $SYSLIB
     fi
 
   fi

--- a/rcli.sh
+++ b/rcli.sh
@@ -447,7 +447,7 @@ function install() {
     # checks if /opt/R/ contains any R installations
     firstTime=$(ls -l /opt/R | awk '/^d/ { print $9 }' | grep "^[0-9][^/]*$" | sed "s/^/- /")
     # checks if the user has installed any custom libraries into the system lib
-    if [[ $currentR != $R_VERSION && ${#firstTime} == 0 && $(find $SYSLIB -maxdepth 1 -type d | wc -l | xargs) != 31 ]]; then
+    if [[ $currentR != $R_VERSION && ${#firstTime} == 0 && $(find $SYSLIB -maxdepth 1 -type d | wc -l | xargs) > 31 ]]; then
       echo -e "⚠️  ⚠️  ⚠️\nHey there! It seems you are using \033[36mrcli\033[0m for the first time and trying to install an R version different from the one you are currently running. This is a problem if you do not make use of a user library (which it seems like) and instead install all your packages into your system library (which is the unfortunate default on macOS, so don't worry about having done anything wrong). To prevent package loss, please first run \033[36mrcli install $currentR\033[0m so your existing packages are retained.\n"
 
       echo -e "\033[36mrcli\033[0m is able to account for this approach by copying things around - however R version switching might take a bit longer. Please consider using a user library for your personal packages. You can do so by calling \033[36mmkdir -p /Users/$(whoami)/Library/R/$R_CUT\033[0m (x86) or \033[36mmkdir -p /Users/$(whoami)/Library/R/arm64/$R_CUT\033[0m (arm64) from the terminal. Note that this needs to be done for every R minor version (e.g. 4.1, 4.0 and so forth) and architecture.\n"

--- a/rcli.sh
+++ b/rcli.sh
@@ -213,7 +213,7 @@ function switch() {
         if [[ $ARG_DEBUG == 1 ]]; then
           echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
         fi
-        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/ /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       # clean
@@ -356,7 +356,7 @@ function switch() {
         if [[ $ARG_DEBUG == 1 ]]; then
           echo -e "DEBUG: switch(): Restoring existing syslib"
         fi
-        sudo cp -fR /opt/R/$R_VERSION/syslib-bak/ /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        sudo cp -fR /opt/R/$R_VERSION/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       sudo rm -rf /Library/Frameworks/R.framework/Versions/syslib-bak

--- a/rcli.sh
+++ b/rcli.sh
@@ -237,7 +237,7 @@ function switch() {
 
   else
 
-    # ARM -> X86 switch
+    # -> X86 switch
     if [[ $ARG_DEBUG == 1 ]]; then
       echo "DEBUG: Switching: arm -> x86"
     fi

--- a/rcli.sh
+++ b/rcli.sh
@@ -239,7 +239,7 @@ function switch() {
 
     # -> X86 switch
     if [[ $ARG_DEBUG == 1 ]]; then
-      echo "DEBUG: Switching: arm -> x86"
+      echo "DEBUG: Switching: -> x86"
     fi
 
     exists=$(test -d /opt/R/$R_VERSION && echo "true" || echo "false")
@@ -273,6 +273,10 @@ function switch() {
 
     if [[ $(find $SYSLIB -maxdepth 1 -type d | wc -l | xargs) > 31 ]]; then
 
+      if [[ $ARG_DEBUG == 1 ]]; then
+        echo -e "DEBUG: switch(): Backing up system libraries"
+      fi
+
       sudo mkdir -p /opt/R/$CURRENT_R_VERSION_ARCH/syslib-bak
       sudo cp -fR $SYSLIB/ /opt/R/$CURRENT_R_VERSION_ARCH/syslib-bak
 
@@ -297,6 +301,9 @@ function switch() {
       ### restore syslib from target version if it exists
       # only restore if R_VERSION has a syslib-bak
       if [[ $(test -d /opt/R/TARGET_R_VERSION_ARCH/syslib-bak && echo "true" || echo "false") == "true" ]]; then
+        if [[ $ARG_DEBUG == 1 ]]; then
+          echo -e "DEBUG: switch(): Restoring existing syslib"
+        fi
         sudo cp -fR /opt/R/TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 

--- a/rcli.sh
+++ b/rcli.sh
@@ -280,7 +280,7 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT/Resources /Library/Frameworks/R.framework 2>/dev/null
 
-      if [[ $ARG_ARCH == "x86_64" ]]; then
+      if [[ $ARG_ARCH == "x86_64" || $(arch) != "arm64"]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
       else

--- a/rcli.sh
+++ b/rcli.sh
@@ -218,10 +218,8 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION-arm64/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT-arm64/Resources /Library/Frameworks/R.framework/ 2>/dev/null
 
-      if [[ $(arch) == "x86_64" ]]; then
-        TARGET_R_VERSION_ARCH=$R_VERSION
-        TARGET_R_CUT_ARCH=$R_CUT
-      fi
+      TARGET_R_VERSION_ARCH=$R_VERSION
+      TARGET_R_CUT_ARCH=$R_CUT
       if [[ $(arch) == "arm64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION-arm64
         TARGET_R_CUT_ARCH=$R_CUT-arm64
@@ -295,10 +293,8 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT/Resources /Library/Frameworks/R.framework 2>/dev/null
 
-      if [[ $(arch) == "x86_64" ]]; then
-        TARGET_R_VERSION_ARCH=$R_VERSION
-        TARGET_R_CUT_ARCH=$R_CUT
-      fi
+      TARGET_R_VERSION_ARCH=$R_VERSION
+      TARGET_R_CUT_ARCH=$R_CUT
       if [[ $(arch) == "arm64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION-arm64
         TARGET_R_CUT_ARCH=$R_CUT-arm64
@@ -330,15 +326,16 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT/Resources /Library/Frameworks/R.framework/ 2>/dev/null
 
+      TARGET_R_VERSION_ARCH=$R_VERSION
+      TARGET_R_CUT_ARCH=$R_CUT
+      if [[ $(arch) == "arm64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
+        TARGET_R_CUT_ARCH=$R_CUT-arm64
+      fi
+      # override with user preference
       if [[ $ARG_ARCH == "x86_64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
-      elif [[ $(arch) != "arm64" ]]; then
-        TARGET_R_VERSION_ARCH=$R_VERSION
-        TARGET_R_CUT_ARCH=$R_CUT
-      else
-        TARGET_R_VERSION_ARCH=$R_VERSION-arm64
-        TARGET_R_CUT_ARCH=$R_CUT-arm64
       fi
 
       # need 775 permissions

--- a/rcli.sh
+++ b/rcli.sh
@@ -312,6 +312,9 @@ function switch() {
       if [[ $ARG_ARCH == "x86_64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
+      elif [[ $(arch) != "arm64" ]]; then
+        TARGET_R_VERSION_ARCH=$R_VERSION
+        TARGET_R_CUT_ARCH=$R_CUT
       else
         TARGET_R_VERSION_ARCH=$R_VERSION-arm64
         TARGET_R_CUT_ARCH=$R_CUT-arm64

--- a/rcli.sh
+++ b/rcli.sh
@@ -246,7 +246,7 @@ function switch() {
         if [[ $ARG_DEBUG == 1 ]]; then
           echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
         fi
-        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/* /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       sudo rm -rf /Library/Frameworks/R.framework/Versions/syslib-bak
@@ -324,7 +324,7 @@ function switch() {
         if [[ $ARG_DEBUG == 1 ]]; then
           echo -e "DEBUG: switch(): Restoring existing syslib from /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak into /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library"
         fi
-        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/* /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       # clean
@@ -356,7 +356,7 @@ function switch() {
         if [[ $ARG_DEBUG == 1 ]]; then
           echo -e "DEBUG: switch(): Restoring existing syslib"
         fi
-        sudo cp -fR /opt/R/$R_VERSION/syslib-bak /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
+        sudo cp -fR /opt/R/$TARGET_R_VERSION_ARCH/syslib-bak/* /Library/Frameworks/R.framework/Versions/$TARGET_R_CUT_ARCH/Resources/library
       fi
 
       sudo rm -rf /Library/Frameworks/R.framework/Versions/syslib-bak

--- a/rcli.sh
+++ b/rcli.sh
@@ -280,7 +280,7 @@ function switch() {
       sudo cp -fR /opt/R/$R_VERSION/ /Library/Frameworks/R.framework/Versions 2>/dev/null
       sudo cp -fR /opt/R/$R_VERSION/$R_CUT/Resources /Library/Frameworks/R.framework 2>/dev/null
 
-      if [[ $ARG_ARCH == "x86_64" || $(arch) != "arm64"]]; then
+      if [[ $ARG_ARCH == "x86_64" || $(arch) != "arm64" ]]; then
         TARGET_R_VERSION_ARCH=$R_VERSION
         TARGET_R_CUT_ARCH=$R_CUT
       else

--- a/tests/centos8/test-centos8.sh
+++ b/tests/centos8/test-centos8.sh
@@ -1,8 +1,8 @@
 mkdir /tmp/test-results
-rcli install 4.1.2 >>/tmp/test-results/out.txt
+./rcli.sh install 4.1.2 >>/tmp/test-results/out.txt
 R -q -s -e "R.version.string" >/tmp/test-results/out.txt
-rcli install 3.6.3 >>/tmp/test-results/out.txt
+./rcli.sh install 3.6.3 >>/tmp/test-results/out.txt
 R -q -s -e "R.version.string" >>/tmp/test-results/out.txt
-rcli switch 4.1.2 >>/tmp/test-results/out.txt
+./rcli.sh switch 4.1.2 >>/tmp/test-results/out.txt
 R -q -s -e "R.version.string" >>/tmp/test-results/out.txt
 if [[ $(diff tests/centos8/test-out.txt /tmp/test-results/out.txt) == "" ]]; then exit 0; else diff --unified tests/centos8/test-out.txt /tmp/test-results/out.txt && exit 1; fi

--- a/tests/centos8/test-centos8.sh
+++ b/tests/centos8/test-centos8.sh
@@ -1,0 +1,8 @@
+mkdir /tmp/test-results
+rcli install 4.1.2 >>/tmp/test-results/out.txt
+R -q -s -e "R.version.string" >/tmp/test-results/out.txt
+rcli install 3.6.3 >>/tmp/test-results/out.txt
+R -q -s -e "R.version.string" >>/tmp/test-results/out.txt
+rcli switch 4.1.2 >>/tmp/test-results/out.txt
+R -q -s -e "R.version.string" >>/tmp/test-results/out.txt
+if [[ $(diff tests/centos8/test-out.txt /tmp/test-results/out.txt) == "" ]]; then exit 0; else diff --unified tests/centos8/test-out.txt /tmp/test-results/out.txt && exit 1; fi

--- a/tests/macos/test-out-x86.txt
+++ b/tests/macos/test-out-x86.txt
@@ -1,0 +1,9 @@
+[1] "R version 4.1.2 (2021-11-01)"
+[1] "R version 4.0.5 (2021-03-31)"
+DEBUG: Switching: -> x86
+DEBUG: n(packages) in syslib: 33
+DEBUG: switch(): Backing up system library to /opt/R/4.1.2/syslib-bak
+DEBUG: Switching: -> x86
+DEBUG: n(packages) in syslib: 32
+DEBUG: switch(): Backing up system library to /opt/R/4.0.5/syslib-bak
+DEBUG: switch(): Restoring existing syslib from /opt/R/4.1.2/syslib-bak into /Library/Frameworks/R.framework/Versions/4.1/Resources/library

--- a/tests/macos/test.sh
+++ b/tests/macos/test.sh
@@ -1,0 +1,17 @@
+mkdir -p /tmp/test-results && touch /tmp/test-results/out.txt
+./rcli.sh install 4.1.2 && R -q -s -e "R.version.string" >>/tmp/test-results/out.txt
+./rcli.sh install 4.0.5 && R -q -s -e "R.version.string" >>/tmp/test-results/out.txt
+echo -e "#### Switching 4.0.5 -> 4.1.2"
+./rcli.sh switch 4.1.2 >>/tmp/test-results/out.txt
+R -q -s -e "install.packages('gam', repos = 'https://cran.us.r-project.org', quiet = TRUE)" >/dev/null
+echo -e "#### Switching 4.1.2 -> 4.0.5"
+./rcli.sh switch 4.0.5 --debug >>/tmp/test-results/out.txt
+R -q -s -e "install.packages('cli', repos = 'https://cran.us.r-project.org', quiet = TRUE)" >/dev/null
+echo -e "#### Switching 4.0.5 -> 4.1.2"
+./rcli.sh switch 4.1.2 --debug >>/tmp/test-results/out.txt
+R -q -s -e "library('gam')" >>/tmp/test-results/out.txt
+echo -e "#### Installing R devel"
+./rcli.sh install devel
+echo -e "#### Switching devel -> 4.0.5"
+./rcli.sh switch 4.0.5 >>/tmp/test-results/out.txt
+R -q -s -e "library('cli')" >>/tmp/test-results/out.txt

--- a/tests/ubuntu-20.04/test-ubuntu-20.04.sh
+++ b/tests/ubuntu-20.04/test-ubuntu-20.04.sh
@@ -1,0 +1,9 @@
+mkdir -p /tmp/test-results
+chmod +x /usr/local/bin/./rcli.sh
+./rcli.sh install 4.1.2 >>/tmp/test-results/out
+R -q -s -e "R.version.string" >/tmp/test-results/out
+./rcli.sh install 3.6.3 >>/tmp/test-results/out
+R -q -s -e "R.version.string" >>/tmp/test-results/out
+./rcli.sh switch 4.1.2 >>/tmp/test-results/out
+R -q -s -e "R.version.string" >>/tmp/test-results/out
+if [[ $(diff tests/ubuntu-20.04/test-out.txt /tmp/test-results/out) == "" ]]; then exit 0; else exit 1; fi


### PR DESCRIPTION
- use `bashcov` for coverage
- add tests switching between R devel and other R version
- check preservation of custom system library packages
- add codecov for ubuntu20 and centos8 tests